### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/api-quality.yml
+++ b/.github/workflows/api-quality.yml
@@ -12,6 +12,9 @@ on:
       - 'api/**'
       - '.github/workflows/api-quality.yml'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Format


### PR DESCRIPTION
Potential fix for [https://github.com/jbouder/starkiller/security/code-scanning/8](https://github.com/jbouder/starkiller/security/code-scanning/8)

In general, the fix is to explicitly declare restricted `GITHUB_TOKEN` permissions for the workflow or each job, instead of relying on the repository/organization defaults. Since none of these jobs need to push commits, change releases, or modify issues/PRs, we can safely restrict `contents` to `read` and omit any other write permissions.

The best minimal, non-breaking fix here is to add a single `permissions:` block at the workflow root (top level, alongside `on:` and `jobs:`). That block will apply to all jobs that don’t override it. Based on the steps, all jobs just need read access to repository contents and no other scopes. So we’ll add:

```yaml
permissions:
  contents: read
```

right after the `on:` section and before `jobs:`. No other changes are needed: the `actions/checkout`, `actions/setup-python`, and `codecov/codecov-action` steps will continue to function with read-only contents access. We do not need any imports or additional methods because this is a YAML configuration change only.

Concretely, in `.github/workflows/api-quality.yml`, we will insert the `permissions:` block between the existing triggers (`on:`) and the `jobs:` definition. No other lines need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
