### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ui-quality.yml
+++ b/.github/workflows/ui-quality.yml
@@ -12,6 +12,9 @@ on:
       - "ui/**"
       - ".github/workflows/ui-quality.yml"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/jbouder/starkiller/security/code-scanning/6](https://github.com/jbouder/starkiller/security/code-scanning/6)

To fix the problem, explicitly scope down the `GITHUB_TOKEN` permissions used by this workflow. Since both `lint` and `typecheck` only need to check out code and run Node-based commands, the minimal required permission is `contents: read`. This can be set once at the workflow root so it applies to all jobs that don’t override it.

The best fix without changing existing functionality is:

- Add a `permissions:` block at the top level of `.github/workflows/ui-quality.yml`, between the `on:` section and the `jobs:` section.
- Set `contents: read` inside this block. This will give the `actions/checkout` step enough permissions to fetch the repository contents while preventing unnecessary write access.

Concretely, in `.github/workflows/ui-quality.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 13 (the last `paths:` entry under `pull_request:`) and before line 15 (`jobs:`). No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
